### PR TITLE
Remove Breadcrumbs::withoutHomeItem(), rename variables

### DIFF
--- a/docs/breadcrumbs.md
+++ b/docs/breadcrumbs.md
@@ -64,8 +64,7 @@ Method | Description | Default
 `id(string $value)` | Widget ID. | `''`
 `autoIdPrefix(string $value)` | Prefix to the automatically generated widget ID. | `w`
 `withoutEncodeLabels()` | Disable encoding for labels. | `false`
-`withoutHomeItem()` | Do not render home item. | `true`
-`homeItem(array $value)` | The first item in the breadcrumbs (called home link). | `[]`
+`homeItem(array $value)` | The first item in the breadcrumbs (called home link). | `['label' => 'Home', 'url' => '/']`
 `itemTemplate(string $value)` | Template used to render each inactive item in the breadcrumbs. | `<li>{icon}{link}</li>\n`
 `activeItemTemplate(string $value)`| Template used to render each active item in the breadcrumbs. | `<li class=\"is-active\"><a aria-current=\"page\">{icon}{label}</li>\n`
 `items(array $value)` | List of items to appear in the breadcrumbs. | `[]`

--- a/docs/breadcrumbs.md
+++ b/docs/breadcrumbs.md
@@ -64,7 +64,7 @@ Method | Description | Default
 `id(string $value)` | Widget ID. | `''`
 `autoIdPrefix(string $value)` | Prefix to the automatically generated widget ID. | `w`
 `withoutEncodeLabels()` | Disable encoding for labels. | `false`
-`homeItem(array $value)` | The first item in the breadcrumbs (called home link). | `['label' => 'Home', 'url' => '/']`
+`homeItem(?array $value)` | The first item in the breadcrumbs (called home link). | `['label' => 'Home', 'url' => '/']`
 `itemTemplate(string $value)` | Template used to render each inactive item in the breadcrumbs. | `<li>{icon}{link}</li>\n`
 `activeItemTemplate(string $value)`| Template used to render each active item in the breadcrumbs. | `<li class=\"is-active\"><a aria-current=\"page\">{icon}{label}</li>\n`
 `items(array $value)` | List of items to appear in the breadcrumbs. | `[]`

--- a/src/Breadcrumbs.php
+++ b/src/Breadcrumbs.php
@@ -30,7 +30,7 @@ use function strtr;
 final class Breadcrumbs extends Widget
 {
     private bool $encodeLabels = true;
-    private array $homeItem = ['label' => 'Home', 'url' => '/'];
+    private ?array $homeItem = ['label' => 'Home', 'url' => '/'];
     private string $itemTemplate = "<li>{icon}{link}</li>\n";
     private string $activeItemTemplate = "<li class=\"is-active\"><a aria-current=\"page\">{icon}{label}</a></li>\n";
     private array $items = [];
@@ -66,18 +66,24 @@ final class Breadcrumbs extends Widget
     }
 
     /**
-     * The first item in the breadcrumbs (called home link).
+     * Returns a new instance with the specified first item in the breadcrumbs (called home link).
      *
-     * If an empty array is specified, the home item will not be rendered.
+     * If a null is specified, the home item will not be rendered.
      *
-     * Please refer to {@see $items} on the format.
+     * @param array|null $value Please refer to {@see items()} on the format.
      *
-     * @param array $value
+     * @throws InvalidArgumentException If an empty array is specified.
      *
      * @return self
      */
-    public function homeItem(array $value): self
+    public function homeItem(?array $value): self
     {
+        if ($value === []) {
+            throw new InvalidArgumentException(
+                'The home item cannot be an empty array. To disable rendering of the home item, specify null.',
+            );
+        }
+
         $new = clone $this;
         $new->homeItem = $value;
         return $new;
@@ -252,7 +258,7 @@ final class Breadcrumbs extends Widget
     {
         $items = [];
 
-        if (!empty($this->homeItem)) {
+        if ($this->homeItem !== null) {
             $items[] = $this->renderItem($this->homeItem, $this->itemTemplate);
         }
 

--- a/tests/BreadcrumbsTest.php
+++ b/tests/BreadcrumbsTest.php
@@ -273,7 +273,7 @@ final class BreadcrumbsTest extends TestCase
 
         $html = Breadcrumbs::widget()
             ->items([['label' => 'About', 'url' => '/about']])
-            ->withoutHomeItem()
+            ->homeItem([])
             ->render();
         $expected = <<<'HTML'
         <nav id="w1-breadcrumbs" class="breadcrumb" aria-label="breadcrumbs">
@@ -290,7 +290,6 @@ final class BreadcrumbsTest extends TestCase
         $widget = Breadcrumbs::widget();
 
         $this->assertNotSame($widget, $widget->homeItem([]));
-        $this->assertNotSame($widget, $widget->withoutHomeItem());
         $this->assertNotSame($widget, $widget->itemTemplate(''));
         $this->assertNotSame($widget, $widget->activeItemTemplate(''));
         $this->assertNotSame($widget, $widget->items([]));

--- a/tests/BreadcrumbsTest.php
+++ b/tests/BreadcrumbsTest.php
@@ -186,7 +186,7 @@ final class BreadcrumbsTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('The "label" element is required for each link.');
-        $html = Breadcrumbs::widget()
+        Breadcrumbs::widget()
             ->items([['url' => '/about', 'template' => '<div>{link}</div>']])
             ->render();
     }
@@ -273,7 +273,7 @@ final class BreadcrumbsTest extends TestCase
 
         $html = Breadcrumbs::widget()
             ->items([['label' => 'About', 'url' => '/about']])
-            ->homeItem([])
+            ->homeItem(null)
             ->render();
         $expected = <<<'HTML'
         <nav id="w1-breadcrumbs" class="breadcrumb" aria-label="breadcrumbs">
@@ -285,11 +285,20 @@ final class BreadcrumbsTest extends TestCase
         $this->assertEqualsWithoutLE($expected, $html);
     }
 
+    public function testHomeItemThrowExceptionForEmptyArray(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(
+            'The home item cannot be an empty array. To disable rendering of the home item, specify null.',
+        );
+        Breadcrumbs::widget()->homeItem([]);
+    }
+
     public function testImmutability(): void
     {
         $widget = Breadcrumbs::widget();
 
-        $this->assertNotSame($widget, $widget->homeItem([]));
+        $this->assertNotSame($widget, $widget->homeItem(null));
         $this->assertNotSame($widget, $widget->itemTemplate(''));
         $this->assertNotSame($widget, $widget->activeItemTemplate(''));
         $this->assertNotSame($widget, $widget->items([]));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ✔️
| Fixed issues  | -
